### PR TITLE
fix pagination where query params were appending instead of replacing

### DIFF
--- a/lib/cursor/models/page_scope_methods.rb
+++ b/lib/cursor/models/page_scope_methods.rb
@@ -14,50 +14,59 @@ module Cursor
 
     # TODO: are these 2 methods triggering multiple db hits? want to run this on cached result
     def next_cursor
-      @_next_cursor ||= all.last.id
+      @_next_cursor ||= all.last.try(:id)
     end
 
     def prev_cursor
-      @_prev_cursor ||= all.first.id
+      @_prev_cursor ||= all.first.try(:id)
     end
 
-    def next_url request_url, query_params
+    def next_url request_url
       direction == :after ? 
-        after_url(request_url, query_params, next_cursor) :
-        before_url(request_url, query_params, next_cursor)
+        after_url(request_url, next_cursor) :
+        before_url(request_url, next_cursor)
     end
 
-    def prev_url request_url, query_params
+    def prev_url request_url
       direction == :after ? 
-        before_url(request_url, query_params, prev_cursor) :
-        after_url(request_url, query_params, prev_cursor)
+        before_url(request_url, prev_cursor) :
+        after_url(request_url, prev_cursor)
     end
 
-    def before_url request_url, query_params, cursor
-      "#{request_url}?#{query_params.merge(Cursor.config.before_param_name => cursor).to_query}"
+    def before_url request_url, cursor
+      base, params = url_parts(request_url)
+      params.merge!(Cursor.config.before_param_name.to_s => cursor) unless cursor.nil?
+      params.to_query.length > 0 ? "#{base}?#{params.to_query}" : base
     end
 
-    def after_url request_url, query_params, cursor
-      "#{request_url}?#{query_params.merge(Cursor.config.after_param_name => cursor).to_query}"
+    def after_url request_url, cursor
+      base, params = url_parts(request_url)
+      params.merge!(Cursor.config.after_param_name.to_s => cursor) unless cursor.nil?
+      params.to_query.length > 0 ? "#{base}?#{params.to_query}" : base
     end
 
     def url_parts request_url
+      base = request_url.split('?')[0]
+      params = CGI.parse(request_url.split('?')[1] || '')
+      params.stringify_keys!
+      params.delete('before')
+      params.delete('after')
+      [base, params]
     end
 
     def direction
+      return :after if prev_cursor.nil? && next_cursor.nil?
       @_direction ||= prev_cursor < next_cursor ? :after : :before
     end
 
-    def pagination request_url, query_params
-      query_params.delete(:after)
-      query_params.delete(:before)
-      request_params ||= {}
-      {
+    def pagination request_url
+      h = {
         next_cursor: next_cursor,
-        prev_cursor: prev_cursor,
-        next_url: next_url(request_url, query_params),
-        prev_url: prev_url(request_url, query_params)
+        prev_cursor: prev_cursor
       }
+      h[:next_url] = next_url(request_url) unless next_cursor.nil?
+      h[:prev_url] = prev_url(request_url) unless prev_cursor.nil?
+      h
     end
   end
 end

--- a/spec/models/active_record/scopes_spec.rb
+++ b/spec/models/active_record/scopes_spec.rb
@@ -40,8 +40,8 @@ if defined? ActiveRecord
     it {
       expect(subject[:next_url]).to include('before=76')
       expect(subject[:prev_url]).to include('after=100')
-      expect(subject[:next_url].count('after')/'after'.length).to eq(1)
-      expect(subject[:prev_url].count('before')/'before'.length).to eq(1)
+      expect(subject[:prev_url].scan('after').length).to eq(1)
+      expect(subject[:next_url].scan('before').length).to eq(1)
       expect(subject[:next_url]).to_not include('after')
       expect(subject[:prev_url]).to_not include('before')
     }
@@ -51,13 +51,31 @@ if defined? ActiveRecord
     it {
       expect(subject[:next_url]).to include('after=25')
       expect(subject[:prev_url]).to include('before=1')
-      expect(subject[:next_url].count('after')/'after'.length).to eq(1)
-      expect(subject[:prev_url].count('before')/'before'.length).to eq(1)
+      expect(subject[:next_url].scan('after').length).to eq(1)
+      expect(subject[:prev_url].scan('before').length).to eq(1)
       expect(subject[:next_url]).to_not include('before')
       expect(subject[:prev_url]).to_not include('after')
     }
   end
 
+
+  describe Cursor::ActiveRecordExtension do
+    it 'returns no after cursor when there are no records' do
+      params = User.page(after: 0).pagination('http://example.com')
+      expect(params.has_key?(:next_url)).to be_false
+      expect(params.has_key?(:prev_url)).to be_false
+      expect(params[:next_cursor]).to be_nil
+      expect(params[:prev_cursor]).to be_nil
+    end
+
+    it 'returns no before cursor when there are no records' do
+      params = User.page(before: 0).pagination('http://example.com')
+      expect(params.has_key?(:next_url)).to be_false
+      expect(params.has_key?(:prev_url)).to be_false
+      expect(params[:next_cursor]).to be_nil
+      expect(params[:prev_cursor]).to be_nil
+    end
+  end
 
 
   describe Cursor::ActiveRecordExtension do
@@ -185,33 +203,33 @@ if defined? ActiveRecord
 
         describe '#pagination' do
           context 'before' do
-            subject { model_class.page.pagination('http://example.com', {}) }
+            subject { model_class.page.pagination('http://example.com') }
             it_should_behave_like 'before pagination'
           end
 
 
           context 'after' do
-            subject { model_class.page(after: 0).pagination('http://example.com', {}) }
+            subject { model_class.page(after: 0).pagination('http://example.com') }
             it_should_behave_like 'after pagination'
           end
 
           context 'before with existing before query param' do
-            subject { model_class.page(before: 101).pagination('http://example.com', {before: 10}) }
+            subject { model_class.page(before: 101).pagination('http://example.com?before=10') }
             it_should_behave_like 'before pagination'
           end
 
           context 'before with existing after query param' do
-            subject { model_class.page(before: 101).pagination('http://example.com', {after: 10}) }
+            subject { model_class.page(before: 101).pagination('http://example.com?after=10') }
             it_should_behave_like 'before pagination'
           end
 
           context 'after with existing after query param' do
-            subject { model_class.page(after: 0).pagination('http://example.com', {after: 10}) }
+            subject { model_class.page(after: 0).pagination('http://example.com?after=10') }
             it_should_behave_like 'after pagination'
           end
 
           context 'after with existing before query param' do
-            subject { model_class.page(after: 0).pagination('http://example.com', {before: 10}) }
+            subject { model_class.page(after: 0).pagination('http://example.com?before=10') }
             it_should_behave_like 'after pagination'
           end
 


### PR DESCRIPTION
breaking change: the pagination method now just takes the request_url, query params do not need to be passed separately
