### PR TITLE
Fix AR exdending

### DIFF
--- a/lib/cursor/models/active_record_extension.rb
+++ b/lib/cursor/models/active_record_extension.rb
@@ -1,20 +1,18 @@
 require 'cursor/models/active_record_model_extension'
 
 module Cursor
-
-  module InheritedOverride
-    def inherited(kls)
-      inherited_without_cursor kls
-      kls.send(:include, Cursor::ActiveRecordModelExtension) if kls.superclass == ::ActiveRecord::Base
-    end
-  end
-
   module ActiveRecordExtension
     extend ActiveSupport::Concern
-    included do
-      # Future subclasses will pick up the model extension
-      self.prepend Cursor::InheritedOverride
 
+    module ClassMethods
+      # Future subclasses will pick up the model extension
+      def inherited(kls) #:nodoc:
+        super
+        kls.send(:include, Cursor::ActiveRecordModelExtension) if kls.superclass == ::ActiveRecord::Base
+      end
+    end
+
+    included do
       # Existing subclasses pick up the model extension as well
       self.descendants.each do |kls|
         kls.send(:include, Cursor::ActiveRecordModelExtension) if kls.superclass == ::ActiveRecord::Base


### PR DESCRIPTION
Fix AR model extending.

With out fix:
```
# BUNDLE_GEMFILE='gemfiles/active_record_42.gemfile' bundle exec rspec
...
  119) configuration methods #max_per_page when configuring multiple times limit_value
     Failure/Error: attribute_chain.inject(subject) do |inner_subject, attr|
     NoMethodError:
       undefined method `page' for User(id: integer, name: string, age: integer):Class
     # ./spec/models/configuration_methods_spec.rb:52:in `block (3 levels) in <top (required)>'
     # ./spec/models/configuration_methods_spec.rb:73:in `block (4 levels) in <top (required)>'

Finished in 1 minute 17.46 seconds
164 examples, 119 failures
```