### PR TITLE
Change Default Page Method

### DIFF
--- a/lib/cursor/config.rb
+++ b/lib/cursor/config.rb
@@ -6,22 +6,33 @@ module Cursor
   #     config.default_per_page = 10
   #   end
   def self.configure(&block)
-    yield @config ||= Cursor::Configuration.new
+    yield config
   end
 
   # Global settings for Cursor
   def self.config
-    @config
+    @config ||= Cursor::Configuration.new
   end
 
   # need a Class for 3.0
   class Configuration #:nodoc:
     include ActiveSupport::Configurable
-    config_accessor :default_per_page
-    config_accessor :max_per_page
-    config_accessor :page_method_name
-    config_accessor :before_param_name
-    config_accessor :after_param_name
+
+    config_accessor :default_per_page do
+      25
+    end
+    config_accessor :max_per_page do
+      nil
+    end
+    config_accessor :page_method_name do
+      :cursor
+    end
+    config_accessor :before_param_name do
+      :before
+    end
+    config_accessor :after_param_name do
+      :after
+    end
 
     def before_param_name
       config.before_param_name.respond_to?(:call) ? config.before_param_name.call : config.before_param_name
@@ -30,25 +41,5 @@ module Cursor
     def after_param_name
       config.after_param_name.respond_to?(:call) ? config.after_param_name.call : config.after_param_name
     end
-
-
-    # define param_name writer (copied from AS::Configurable)
-    writer, line = 'def before_param_name=(value); config.before_param_name = value; end', __LINE__
-    singleton_class.class_eval writer, __FILE__, line
-    class_eval writer, __FILE__, line
-
-    writer, line = 'def after_param_name=(value); config.after_param_name = value; end', __LINE__
-    singleton_class.class_eval writer, __FILE__, line
-    class_eval writer, __FILE__, line
-
-  end
-
-  # this is ugly. why can't we pass the default value to config_accessor...?
-  configure do |config|
-    config.default_per_page = 25
-    config.max_per_page = nil
-    config.page_method_name = :page
-    config.before_param_name = :before
-    config.after_param_name = :after
   end
 end

--- a/lib/cursor/models/active_record_extension.rb
+++ b/lib/cursor/models/active_record_extension.rb
@@ -1,17 +1,17 @@
 require 'cursor/models/active_record_model_extension'
 
+module CursorInheritance
+  def inherited(kls)
+    super kls
+    kls.send(:include, Cursor::ActiveRecordModelExtension) if kls.superclass == ::ActiveRecord::Base
+  end
+end
+
 module Cursor
   module ActiveRecordExtension
     extend ActiveSupport::Concern
     included do
-      # Future subclasses will pick up the model extension
-      class << self
-        def inherited_with_cursor(kls) #:nodoc:
-          inherited_without_cursor kls
-          kls.send(:include, Cursor::ActiveRecordModelExtension) if kls.superclass == ::ActiveRecord::Base
-        end
-        alias_method_chain :inherited, :cursor
-      end
+      prepend CursorInheritance
 
       # Existing subclasses pick up the model extension as well
       self.descendants.each do |kls|

--- a/lib/cursor/models/active_record_extension.rb
+++ b/lib/cursor/models/active_record_extension.rb
@@ -1,18 +1,17 @@
 require 'cursor/models/active_record_model_extension'
 
-module CursorInheritance
-  def inherited(kls)
-    super kls
-    kls.send(:include, Cursor::ActiveRecordModelExtension) if kls.superclass == ::ActiveRecord::Base
-  end
-end
-
 module Cursor
   module ActiveRecordExtension
     extend ActiveSupport::Concern
-    included do
-      prepend CursorInheritance
 
+    module ClassMethods
+      def inherited(kls)
+        super kls
+        kls.send(:include, Cursor::ActiveRecordModelExtension) if kls.superclass == ::ActiveRecord::Base
+      end
+    end
+
+    included do
       # Existing subclasses pick up the model extension as well
       self.descendants.each do |kls|
         kls.send(:include, Cursor::ActiveRecordModelExtension) if kls.superclass == ::ActiveRecord::Base

--- a/lib/cursor/models/active_record_model_extension.rb
+++ b/lib/cursor/models/active_record_model_extension.rb
@@ -1,10 +1,9 @@
-
 module Cursor
   module ActiveRecordModelExtension
     extend ActiveSupport::Concern
 
     included do
-      self.send(:include, Cursor::ConfigurationMethods)
+      include Cursor::ConfigurationMethods
 
       # Fetch the values at the specified page edge
       #   Model.page(after: 5)


### PR DESCRIPTION
Minor adjustments to the config class including:

Removing uneeded methods inherited from ActiveSupport::Configurable
Using blocks to define default values
Change default value of `page_method_name` from `page` to `cursor` (we use `cursor` as the page method in box anyway, but if cursor is loaded after kaminari, the default name `page` overrides kaminari's `page` method before the name is changed to `cursor`.